### PR TITLE
[ZER-689] Added support for parsing ZECv4 non-shielded PSBTs

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -66,6 +66,9 @@ AC_ARG_ENABLE(tests,
 AC_ARG_ENABLE(elements,
     AS_HELP_STRING([--enable-elements],[enable elements tx code (default: no)]),
     [elements=$enableval], [elements=no])
+AC_ARG_ENABLE(zcash,
+    AS_HELP_STRING([--enable-zcash],[enable Zcash v4 transaction support (default: no)]),
+    [zcash=$enableval], [zcash=no])
 AC_ARG_ENABLE(builtin-memset,
     AS_HELP_STRING([--enable-builtin-memset],[disable to add -fno-builtin-memset to compiler flags. helps with explicit_bzero/memset being elided on Linux clang 7.0.1 and up (default: yes)]),
     [builtin_memset=$enableval], [builtin_memset=yes])
@@ -124,6 +127,10 @@ fi
 
 if test "x$minimal" == "xyes"; then
     AX_CHECK_COMPILE_FLAG([-DBUILD_MINIMAL=1], [AM_CFLAGS="$AM_CFLAGS -DBUILD_MINIMAL=1"])
+fi
+
+if test "x$zcash" == "xyes"; then
+    AX_CHECK_COMPILE_FLAG([-DWALLY_ZCASH=1], [AM_CFLAGS="$AM_CFLAGS -DWALLY_ZCASH=1"])
 fi
 
 if test "x$builtin_memset" == "xno"; then

--- a/include/wally_psbt.h
+++ b/include/wally_psbt.h
@@ -139,13 +139,15 @@ struct wally_psbt {
     uint32_t fallback_locktime;
     uint32_t has_fallback_locktime;
     uint32_t tx_modifiable_flags;
-    uint32_t branch_id;
 #ifndef WALLY_ABI_NO_ELEMENTS
     struct wally_map global_scalars;
     uint32_t pset_modifiable_flags;
     unsigned char genesis_blockhash[SHA256_LEN]; /* All zeros if not present */
 #endif /* WALLY_ABI_NO_ELEMENTS */
     struct wally_map *signing_cache;
+#ifdef WALLY_ZCASH
+    uint32_t branch_id;        /* NGRAVE-ZEC: CONSENSUS_BRANCH_ID */
+#endif
 };
 #endif /* SWIG */
 

--- a/include/wally_psbt.h
+++ b/include/wally_psbt.h
@@ -139,6 +139,7 @@ struct wally_psbt {
     uint32_t fallback_locktime;
     uint32_t has_fallback_locktime;
     uint32_t tx_modifiable_flags;
+    uint32_t branch_id;
 #ifndef WALLY_ABI_NO_ELEMENTS
     struct wally_map global_scalars;
     uint32_t pset_modifiable_flags;

--- a/include/wally_transaction.h
+++ b/include/wally_transaction.h
@@ -27,6 +27,7 @@ extern "C" {
 /* Note: This flag encodes/parses transactions that are ambiguous to decode.
    Unless you have a good reason to do so you will most likely not need it */
 #define WALLY_TX_FLAG_PRE_BIP144    0x8 /* Encode/Decode using pre-BIP 144 serialization */
+#define WALLY_TX_FLAG_ZEC_V4        0x10 /* Encode/Decode as a Zcash V4 Sapling transaction */
 
 #define WALLY_TX_FLAG_BLINDED_INITIAL_ISSUANCE 0x1
 
@@ -148,6 +149,8 @@ struct wally_tx_output {
 struct wally_tx {
     uint32_t version;
     uint32_t locktime;
+    uint32_t version_group_id; /* Zcash V4: nVersionGroupId (0x892F2085), else 0 */
+    uint32_t expiry_height;    /* Zcash V4: nExpiryHeight, else 0 */
     struct wally_tx_input *inputs;
     size_t num_inputs;
     size_t inputs_allocation_len;

--- a/include/wally_transaction.h
+++ b/include/wally_transaction.h
@@ -149,14 +149,16 @@ struct wally_tx_output {
 struct wally_tx {
     uint32_t version;
     uint32_t locktime;
-    uint32_t version_group_id; /* Zcash V4: nVersionGroupId (0x892F2085), else 0 */
-    uint32_t expiry_height;    /* Zcash V4: nExpiryHeight, else 0 */
     struct wally_tx_input *inputs;
     size_t num_inputs;
     size_t inputs_allocation_len;
     struct wally_tx_output *outputs;
     size_t num_outputs;
     size_t outputs_allocation_len;
+#ifdef WALLY_ZCASH
+    uint32_t version_group_id; /* NGRAVE-ZEC: nVersionGroupId, else 0 */
+    uint32_t expiry_height;    /* NGRAVE-ZEC: nExpiryHeight, else 0 */
+#endif
 };
 #endif /* SWIG */
 

--- a/include/wally_zcash.h
+++ b/include/wally_zcash.h
@@ -1,0 +1,44 @@
+#ifndef LIBWALLY_CORE_ZCASH_H
+#define LIBWALLY_CORE_ZCASH_H
+
+#include "wally_core.h"
+
+/* NGRAVE-ZEC: ZEC_TX_FLAG expands to "| WALLY_TX_FLAG_ZEC_V4" when
+ * WALLY_ZCASH is defined (--enable-zcash / -DWALLY_ZCASH), else empty. */
+#ifdef WALLY_ZCASH
+#define ZEC_TX_FLAG | WALLY_TX_FLAG_ZEC_V4
+#else
+#define ZEC_TX_FLAG
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct wally_tx;
+struct wally_psbt;
+
+#define ZEC_V4_VERSION_GROUP_ID 0x892F2085u
+
+/* Fixed extra bytes a ZEC V4 tx contributes beyond the base BTC layout:
+ * nVersionGroupId(4) + nExpiryHeight(4) + valueBalanceSapling(8) + 3 zero-varints. */
+size_t zec_v4_extra_length(void);
+
+/* Serialization. Each returns the advanced write cursor. */
+unsigned char *zec_v4_write_header(unsigned char *p, const struct wally_tx *tx);  /* after version  */
+unsigned char *zec_v4_write_trailer(unsigned char *p, const struct wally_tx *tx); /* after locktime */
+
+/* Parsing. */
+bool zec_v4_detect_header(const unsigned char *bytes, size_t len); /* leading 0x04 00 00 80 */
+int  zec_v4_validate_trailer(const unsigned char *p, size_t avail); /* p at locktime; WALLY_OK/EINVAL */
+const unsigned char *zec_v4_read_header(const unsigned char *p, struct wally_tx *tx);  /* after version  */
+const unsigned char *zec_v4_read_trailer(const unsigned char *p, struct wally_tx *tx); /* p at locktime  */
+
+/* PSBT: pull Zcash CONSENSUS_BRANCH_ID out of the proprietary key (BitGo convention).
+ * Sets psbt->branch_id (0 when absent). Always WALLY_OK. */
+int zec_psbt_extract_branch_id(struct wally_psbt *psbt);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* LIBWALLY_CORE_ZCASH_H */

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -48,6 +48,7 @@ libwallylite_la_SOURCES = \
     tx_io.c \
     wif.c \
     wordlist.c \
+    zcash.c \
     ccan/ccan/base64/base64.c \
     ccan/ccan/crypto/ripemd160/ripemd160.c \
     ccan/ccan/crypto/sha256/sha256.c \
@@ -64,7 +65,8 @@ libwallylite_la_INCLUDES = \
     include/wally_psbt.h \
     include/wally_script.h \
     include/wally_symmetric.h \
-    include/wally_transaction.h
+    include/wally_transaction.h \
+    include/wally_zcash.h
 
 libwallylite_la_LDFLAGS = -no-undefined
 

--- a/src/psbt.c
+++ b/src/psbt.c
@@ -1,4 +1,5 @@
 #include "internal.h"
+#include <stdio.h>
 
 #include <include/wally_elements.h>
 #include <include/wally_script.h>
@@ -37,11 +38,13 @@ static const uint8_t PSBT_MAGIC[5] = {'p', 's', 'b', 't', 0xff};
 static const uint8_t PSET_MAGIC[5] = {'p', 's', 'e', 't', 0xff};
 
 /* Zcash V4 Sapling constants */
-#define ZEC_V4_HEADER_BYTES {0x04, 0x00, 0x00, 0x80} /* 0x80000004 LE */
-#define ZEC_V4_HEADER_LEN 4
-#define ZEC_V4_VERSION_GROUP_ID 0x892F2085u
+static const uint32_t ZEC_V4_VERSION_GROUP_ID = 0x892F2085u;
+static const uint8_t  ZEC_V4_HEADER[] = {0x04, 0x00, 0x00, 0x80}; /* 0x80000004 LE */
+static const size_t   ZEC_V4_HEADER_LEN = sizeof(ZEC_V4_HEADER);
 
-static const uint8_t ZEC_V4_HEADER[ZEC_V4_HEADER_LEN] = ZEC_V4_HEADER_BYTES;
+/* PSBT proprietary key for Zcash consensus branch ID (BitGo convention): */
+static const uint8_t ZEC_PROP_KEY_BRANCH_ID[] = {0xFC, 0x05, 0x42, 0x49, 0x54, 0x47, 0x4F, 0x00};
+static const size_t  ZEC_PROP_KEY_BRANCH_ID_LEN = sizeof(ZEC_PROP_KEY_BRANCH_ID);
 
 #define MAX_INVALID_SATOSHI ((uint64_t) -1)
 /* Note we mask given indices regardless of PSBT/PSET, since enormous
@@ -2840,6 +2843,21 @@ unknown:
 
     if (ret == WALLY_OK && !*cursor)
         ret = WALLY_EINVAL; /* Ran out of data */
+
+    /* Extract Zcash consensus branch ID from proprietary keys if present */
+    if (ret == WALLY_OK) {
+        (*output)->branch_id = 0;
+        for (i = 0; i < (*output)->unknowns.num_items; i++) {
+            const struct wally_map_item *item = &(*output)->unknowns.items[i];
+            if (item->key_len == ZEC_PROP_KEY_BRANCH_ID_LEN &&
+                !memcmp(item->key, ZEC_PROP_KEY_BRANCH_ID, ZEC_PROP_KEY_BRANCH_ID_LEN) &&
+                item->value_len == 4) {
+
+                (*output)->branch_id = le32toh(*(const uint32_t *)item->value);
+                break;
+            }
+        }
+    }
 
     if (ret != WALLY_OK) {
         wally_psbt_free(*output);

--- a/src/psbt.c
+++ b/src/psbt.c
@@ -36,6 +36,13 @@
 static const uint8_t PSBT_MAGIC[5] = {'p', 's', 'b', 't', 0xff};
 static const uint8_t PSET_MAGIC[5] = {'p', 's', 'e', 't', 0xff};
 
+/* Zcash V4 Sapling constants */
+#define ZEC_V4_HEADER_BYTES {0x04, 0x00, 0x00, 0x80} /* 0x80000004 LE */
+#define ZEC_V4_HEADER_LEN 4
+#define ZEC_V4_VERSION_GROUP_ID 0x892F2085u
+
+static const uint8_t ZEC_V4_HEADER[ZEC_V4_HEADER_LEN] = ZEC_V4_HEADER_BYTES;
+
 #define MAX_INVALID_SATOSHI ((uint64_t) -1)
 /* Note we mask given indices regardless of PSBT/PSET, since enormous
  * indices can never be valid on BTC either */
@@ -2096,6 +2103,9 @@ static int pull_tx(const unsigned char **cursor, size_t *max,
     if (*tx_out)
         return WALLY_EINVAL; /* Duplicate */
     pull_subfield_start(cursor, max, pull_varint(cursor, max), &val, &val_len);
+    /* Auto-detect ZEC V4: header bytes 0x04 0x00 0x00 0x80 (= 0x80000004 LE) */
+    if (val_len >= ZEC_V4_HEADER_LEN && !memcmp(val, ZEC_V4_HEADER, ZEC_V4_HEADER_LEN))
+        tx_flags |= WALLY_TX_FLAG_ZEC_V4;
     ret = wally_tx_from_bytes(val, val_len, tx_flags, tx_out);
     pull_subfield_end(cursor, max, val, val_len);
     return ret;
@@ -2883,6 +2893,10 @@ static int push_length_and_tx(unsigned char **cursor, size_t *max,
     int ret;
     size_t tx_len;
     unsigned char *p;
+
+    /* Auto-detect ZEC V4 for serialization */
+    if (tx && tx->version_group_id == ZEC_V4_VERSION_GROUP_ID)
+        flags |= WALLY_TX_FLAG_ZEC_V4;
 
     if ((ret = wally_tx_get_length(tx, flags, &tx_len)) != WALLY_OK)
         return ret;

--- a/src/psbt.c
+++ b/src/psbt.c
@@ -1,10 +1,10 @@
 #include "internal.h"
-#include <stdio.h>
 
 #include <include/wally_elements.h>
 #include <include/wally_script.h>
 #include <include/wally_psbt.h>
 #include <include/wally_psbt_members.h>
+#include <include/wally_zcash.h>
 
 #include <limits.h>
 #include "psbt_io.h"
@@ -36,15 +36,6 @@
 
 static const uint8_t PSBT_MAGIC[5] = {'p', 's', 'b', 't', 0xff};
 static const uint8_t PSET_MAGIC[5] = {'p', 's', 'e', 't', 0xff};
-
-/* Zcash V4 Sapling constants */
-static const uint32_t ZEC_V4_VERSION_GROUP_ID = 0x892F2085u;
-static const uint8_t  ZEC_V4_HEADER[] = {0x04, 0x00, 0x00, 0x80}; /* 0x80000004 LE */
-static const size_t   ZEC_V4_HEADER_LEN = sizeof(ZEC_V4_HEADER);
-
-/* PSBT proprietary key for Zcash consensus branch ID (BitGo convention): */
-static const uint8_t ZEC_PROP_KEY_BRANCH_ID[] = {0xFC, 0x05, 0x42, 0x49, 0x54, 0x47, 0x4F, 0x00};
-static const size_t  ZEC_PROP_KEY_BRANCH_ID_LEN = sizeof(ZEC_PROP_KEY_BRANCH_ID);
 
 #define MAX_INVALID_SATOSHI ((uint64_t) -1)
 /* Note we mask given indices regardless of PSBT/PSET, since enormous
@@ -2106,8 +2097,8 @@ static int pull_tx(const unsigned char **cursor, size_t *max,
     if (*tx_out)
         return WALLY_EINVAL; /* Duplicate */
     pull_subfield_start(cursor, max, pull_varint(cursor, max), &val, &val_len);
-    /* Auto-detect ZEC V4: header bytes 0x04 0x00 0x00 0x80 (= 0x80000004 LE) */
-    if (val_len >= ZEC_V4_HEADER_LEN && !memcmp(val, ZEC_V4_HEADER, ZEC_V4_HEADER_LEN))
+    /* Auto-detect ZEC V4 */
+    if (zec_v4_detect_header(val, val_len))
         tx_flags |= WALLY_TX_FLAG_ZEC_V4;
     ret = wally_tx_from_bytes(val, val_len, tx_flags, tx_out);
     pull_subfield_end(cursor, max, val, val_len);
@@ -2845,19 +2836,8 @@ unknown:
         ret = WALLY_EINVAL; /* Ran out of data */
 
     /* Extract Zcash consensus branch ID from proprietary keys if present */
-    if (ret == WALLY_OK) {
-        (*output)->branch_id = 0;
-        for (i = 0; i < (*output)->unknowns.num_items; i++) {
-            const struct wally_map_item *item = &(*output)->unknowns.items[i];
-            if (item->key_len == ZEC_PROP_KEY_BRANCH_ID_LEN &&
-                !memcmp(item->key, ZEC_PROP_KEY_BRANCH_ID, ZEC_PROP_KEY_BRANCH_ID_LEN) &&
-                item->value_len == 4) {
-
-                (*output)->branch_id = le32toh(*(const uint32_t *)item->value);
-                break;
-            }
-        }
-    }
+    if (ret == WALLY_OK)
+        ret = zec_psbt_extract_branch_id(*output);
 
     if (ret != WALLY_OK) {
         wally_psbt_free(*output);

--- a/src/transaction.c
+++ b/src/transaction.c
@@ -15,7 +15,8 @@
 
 #define WALLY_TX_ALL_FLAGS \
     (WALLY_TX_FLAG_USE_WITNESS | WALLY_TX_FLAG_USE_ELEMENTS | \
-     WALLY_TX_FLAG_ALLOW_PARTIAL | WALLY_TX_FLAG_PRE_BIP144)
+     WALLY_TX_FLAG_ALLOW_PARTIAL | WALLY_TX_FLAG_PRE_BIP144 | \
+     WALLY_TX_FLAG_ZEC_V4)
 
 /* We use the maximum DER sig length (plus a byte for the sighash) so that
  * we overestimate the size by a byte or two per tx sig. This allows using
@@ -1719,6 +1720,12 @@ static int tx_get_lengths(const struct wally_tx *tx,
         varint_get_length(tx->num_inputs) +
         varint_get_length(tx->num_outputs) + sizeof(tx->locktime);
 
+    if (flags & WALLY_TX_FLAG_ZEC_V4)
+        n += sizeof(uint32_t) + /* nVersionGroupId */
+             sizeof(uint32_t) + /* nExpiryHeight */
+             sizeof(uint64_t) + /* valueBalanceSapling (always 0) */
+             3;                 /* nShieldedSpend + nShieldedOutput + nJoinSplit (3x varint 0) */
+
     if (is_elements)
         n += sizeof(uint8_t); /* witness flag */
     for (i = 0; i < tx->num_inputs; ++i) {
@@ -2027,7 +2034,9 @@ static int tx_to_bytes(const struct wally_tx *tx,
     }
 
     p += uint32_to_le_bytes(tx->version, p);
-    if (is_elements) {
+    if (flags & WALLY_TX_FLAG_ZEC_V4) {
+        p += uint32_to_le_bytes(tx->version_group_id, p);
+    } else if (is_elements) {
         *p++ = flags & WALLY_TX_FLAG_USE_WITNESS ? 1 : 0;
     } else {
         if (flags & WALLY_TX_FLAG_USE_WITNESS) {
@@ -2096,6 +2105,12 @@ static int tx_to_bytes(const struct wally_tx *tx,
     }
 
     p += uint32_to_le_bytes(tx->locktime, p);
+
+    if (flags & WALLY_TX_FLAG_ZEC_V4) {
+        p += uint32_to_le_bytes(tx->expiry_height, p);
+        memset(p, 0, sizeof(uint64_t) + 3); // valueBalanceSapling(8) + 3 shielded zero-varints
+        p += sizeof(uint64_t) + 3;
+    }
 
 #ifdef BUILD_ELEMENTS
     if (is_elements && (flags & WALLY_TX_FLAG_USE_WITNESS)) {
@@ -2219,6 +2234,7 @@ static int analyze_tx(const unsigned char *bytes, size_t bytes_len,
     size_t i, j;
     struct wally_tx tmp_tx;
     const bool is_elements = flags & WALLY_TX_FLAG_USE_ELEMENTS;
+    const bool is_zec_v4 = flags & WALLY_TX_FLAG_ZEC_V4;
 
     if (num_inputs)
         *num_inputs = 0;
@@ -2234,7 +2250,12 @@ static int analyze_tx(const unsigned char *bytes, size_t bytes_len,
     end = bytes + bytes_len;
     p = bytes + uint32_from_le_bytes(bytes, &tmp_tx.version);
 
-    if (is_elements) {
+    if (is_zec_v4) {
+        /* ZEC V4: Skip nVersionGroupId (4 bytes), no segwit */
+        if ((size_t)(end - p) < sizeof(uint32_t))
+            return WALLY_EINVAL;
+        p += sizeof(uint32_t);
+    } else if (is_elements) {
         if (flags & WALLY_TX_FLAG_PRE_BIP144)
             return WALLY_EINVAL; /* No pre-BIP 144 serialization for elements */
         *expect_witnesses = *p++ != 0;
@@ -2340,7 +2361,19 @@ static int analyze_tx(const unsigned char *bytes, size_t bytes_len,
 
     ensure_n(sizeof(uint32_t)); /* Locktime */
 
-    if (*expect_witnesses && is_elements) {
+    if (is_zec_v4) {
+        /* Locktime(4) + expiryHeight(4) + valueBalanceSapling(8) + 3 shielded-count varints */
+        ensure_n(4 + 4 + 8 + 3);
+        /* valueBalanceSapling bytes 8..15 relative to p must all be 0 */
+        {
+            size_t zv4_k;
+            for (zv4_k = 8; zv4_k < 16; ++zv4_k)
+                if (p[zv4_k]) return WALLY_EINVAL;
+        }
+        // drop this check in case of shieleded transactions support
+        if (p[16] || p[17] || p[18]) /* shielded counts must be 0 */
+            return WALLY_EINVAL;
+    } else if (*expect_witnesses && is_elements) {
         p += sizeof(uint32_t);
         for (i = 0; i < *num_inputs; ++i) {
             ensure_varbuff(&v); /* issuance amount rangeproof */
@@ -2428,7 +2461,9 @@ static int tx_from_bytes(const unsigned char *bytes, size_t bytes_len,
         return ret;
 
     p += uint32_from_le_bytes(p, &(*output)->version);
-    if (is_elements)
+    if (flags & WALLY_TX_FLAG_ZEC_V4) {
+        p += uint32_from_le_bytes(p, &(*output)->version_group_id);
+    } else if (is_elements)
         p++; /* Skip witness flag */
     else if (expect_witnesses)
         p += 2; /* Skip flag bytes */
@@ -2517,6 +2552,13 @@ static int tx_from_bytes(const unsigned char *bytes, size_t bytes_len,
     }
 
     uint32_from_le_bytes(p, &(*output)->locktime);
+
+    if (flags & WALLY_TX_FLAG_ZEC_V4) {
+        p += sizeof(uint32_t); /* advance past locktime */
+        p += uint32_from_le_bytes(p, &(*output)->expiry_height);
+        p += sizeof(uint64_t) + 3; /* skip valueBalanceSapling(8) + 3 shielded zero-varints */
+        (void)p;
+    }
 
 #ifdef BUILD_ELEMENTS
 

--- a/src/transaction.c
+++ b/src/transaction.c
@@ -7,6 +7,7 @@
 #include <include/wally_transaction_members.h>
 #include <include/wally_map.h>
 #include <include/wally_script.h>
+#include <include/wally_zcash.h>
 
 #include <limits.h>
 #include "pullpush.h"
@@ -15,8 +16,8 @@
 
 #define WALLY_TX_ALL_FLAGS \
     (WALLY_TX_FLAG_USE_WITNESS | WALLY_TX_FLAG_USE_ELEMENTS | \
-     WALLY_TX_FLAG_ALLOW_PARTIAL | WALLY_TX_FLAG_PRE_BIP144 | \
-     WALLY_TX_FLAG_ZEC_V4)
+     WALLY_TX_FLAG_ALLOW_PARTIAL | WALLY_TX_FLAG_PRE_BIP144 \
+     ZEC_TX_FLAG) /* NGRAVE-ZEC: "| WALLY_TX_FLAG_ZEC_V4" under WALLY_ZCASH, else empty */
 
 /* We use the maximum DER sig length (plus a byte for the sighash) so that
  * we overestimate the size by a byte or two per tx sig. This allows using
@@ -1721,10 +1722,7 @@ static int tx_get_lengths(const struct wally_tx *tx,
         varint_get_length(tx->num_outputs) + sizeof(tx->locktime);
 
     if (flags & WALLY_TX_FLAG_ZEC_V4)
-        n += sizeof(uint32_t) + /* nVersionGroupId */
-             sizeof(uint32_t) + /* nExpiryHeight */
-             sizeof(uint64_t) + /* valueBalanceSapling (always 0) */
-             3;                 /* nShieldedSpend + nShieldedOutput + nJoinSplit (3x varint 0) */
+        n += zec_v4_extra_length();
 
     if (is_elements)
         n += sizeof(uint8_t); /* witness flag */
@@ -1968,7 +1966,7 @@ int wally_tx_get_hash_prevouts(const struct wally_tx *tx,
     if (tx && num_inputs == 0xffffffff) {
         if (index)
             return WALLY_EINVAL; /* 0xffffffff is only valid with index == 0 */
-       num_inputs = tx->num_inputs;
+        num_inputs = tx->num_inputs;
     }
     if (!tx || index >= tx->num_inputs || !num_inputs ||
         num_inputs > tx->num_inputs || index + num_inputs > tx->num_inputs ||
@@ -2035,7 +2033,7 @@ static int tx_to_bytes(const struct wally_tx *tx,
 
     p += uint32_to_le_bytes(tx->version, p);
     if (flags & WALLY_TX_FLAG_ZEC_V4) {
-        p += uint32_to_le_bytes(tx->version_group_id, p);
+        p = zec_v4_write_header(p, tx);
     } else if (is_elements) {
         *p++ = flags & WALLY_TX_FLAG_USE_WITNESS ? 1 : 0;
     } else {
@@ -2106,11 +2104,8 @@ static int tx_to_bytes(const struct wally_tx *tx,
 
     p += uint32_to_le_bytes(tx->locktime, p);
 
-    if (flags & WALLY_TX_FLAG_ZEC_V4) {
-        p += uint32_to_le_bytes(tx->expiry_height, p);
-        memset(p, 0, sizeof(uint64_t) + 3); // valueBalanceSapling(8) + 3 shielded zero-varints
-        p += sizeof(uint64_t) + 3;
-    }
+    if (flags & WALLY_TX_FLAG_ZEC_V4)
+        p = zec_v4_write_trailer(p, tx);
 
 #ifdef BUILD_ELEMENTS
     if (is_elements && (flags & WALLY_TX_FLAG_USE_WITNESS)) {
@@ -2362,17 +2357,9 @@ static int analyze_tx(const unsigned char *bytes, size_t bytes_len,
     ensure_n(sizeof(uint32_t)); /* Locktime */
 
     if (is_zec_v4) {
-        /* Locktime(4) + expiryHeight(4) + valueBalanceSapling(8) + 3 shielded-count varints */
-        ensure_n(4 + 4 + 8 + 3);
-        /* valueBalanceSapling bytes 8..15 relative to p must all be 0 */
-        {
-            size_t zv4_k;
-            for (zv4_k = 8; zv4_k < 16; ++zv4_k)
-                if (p[zv4_k]) return WALLY_EINVAL;
-        }
-        // drop this check in case of shieleded transactions support
-        if (p[16] || p[17] || p[18]) /* shielded counts must be 0 */
-            return WALLY_EINVAL;
+        int zret = zec_v4_validate_trailer(p, (size_t)(end - p));
+        if (zret != WALLY_OK)
+            return zret;
     } else if (*expect_witnesses && is_elements) {
         p += sizeof(uint32_t);
         for (i = 0; i < *num_inputs; ++i) {
@@ -2462,7 +2449,7 @@ static int tx_from_bytes(const unsigned char *bytes, size_t bytes_len,
 
     p += uint32_from_le_bytes(p, &(*output)->version);
     if (flags & WALLY_TX_FLAG_ZEC_V4) {
-        p += uint32_from_le_bytes(p, &(*output)->version_group_id);
+        p = (unsigned char *)zec_v4_read_header(p, *output);
     } else if (is_elements)
         p++; /* Skip witness flag */
     else if (expect_witnesses)
@@ -2553,12 +2540,8 @@ static int tx_from_bytes(const unsigned char *bytes, size_t bytes_len,
 
     uint32_from_le_bytes(p, &(*output)->locktime);
 
-    if (flags & WALLY_TX_FLAG_ZEC_V4) {
-        p += sizeof(uint32_t); /* advance past locktime */
-        p += uint32_from_le_bytes(p, &(*output)->expiry_height);
-        p += sizeof(uint64_t) + 3; /* skip valueBalanceSapling(8) + 3 shielded zero-varints */
-        (void)p;
-    }
+    if (flags & WALLY_TX_FLAG_ZEC_V4)
+        p = (unsigned char *)zec_v4_read_trailer(p, *output);
 
 #ifdef BUILD_ELEMENTS
 

--- a/src/zcash.c
+++ b/src/zcash.c
@@ -1,0 +1,107 @@
+#include "internal.h"
+#include "script_int.h" /* uint32_to_le_bytes / uint32_from_le_bytes (alignment-safe) */
+
+#include <include/wally_transaction.h>
+#include <include/wally_psbt.h>
+#include <include/wally_map.h>
+
+#include <stdbool.h>
+#include <string.h>
+
+/* The whole feature compiles in only when WALLY_ZCASH is defined; otherwise this
+ * is an empty translation unit so non-ZEC builds are byte-for-byte unaffected. */
+#ifdef WALLY_ZCASH
+
+/* ZEC V4 (Sapling) constants */
+static const uint8_t  ZEC_V4_HEADER[] = {0x04, 0x00, 0x00, 0x80}; /* 0x80000004 LE */
+#define ZEC_V4_HEADER_LEN (sizeof(ZEC_V4_HEADER))
+
+/* Trailer = nExpiryHeight(4) + valueBalanceSapling(8) + 3 shielded-count varints (all 0). */
+#define ZEC_V4_TRAILER_ZEROS (sizeof(uint64_t) + 3) /* valueBalanceSapling + 3 zero-varints */
+
+/* PSBT proprietary key carrying CONSENSUS_BRANCH_ID (BitGo convention). */
+static const uint8_t ZEC_PROP_KEY_BRANCH_ID[] = {0xFC, 0x05, 0x42, 0x49, 0x54, 0x47, 0x4F, 0x00};
+#define ZEC_PROP_KEY_BRANCH_ID_LEN (sizeof(ZEC_PROP_KEY_BRANCH_ID))
+
+size_t zec_v4_extra_length(void)
+{
+    /* nVersionGroupId + nExpiryHeight + valueBalanceSapling + 3 zero-varints */
+    return sizeof(uint32_t) + sizeof(uint32_t) + ZEC_V4_TRAILER_ZEROS;
+}
+
+unsigned char *zec_v4_write_header(unsigned char *p, const struct wally_tx *tx)
+{
+    /* Written immediately after the 4-byte version. */
+    p += uint32_to_le_bytes(tx->version_group_id, p);
+    return p;
+}
+
+unsigned char *zec_v4_write_trailer(unsigned char *p, const struct wally_tx *tx)
+{
+    /* Written immediately after the 4-byte locktime. */
+    p += uint32_to_le_bytes(tx->expiry_height, p);
+    memset(p, 0, ZEC_V4_TRAILER_ZEROS); /* valueBalanceSapling(0) + 3 shielded counts(0) */
+    p += ZEC_V4_TRAILER_ZEROS;
+    return p;
+}
+
+bool zec_v4_detect_header(const unsigned char *bytes, size_t len)
+{
+    return len >= ZEC_V4_HEADER_LEN && !memcmp(bytes, ZEC_V4_HEADER, ZEC_V4_HEADER_LEN);
+}
+
+int zec_v4_validate_trailer(const unsigned char *p, size_t avail)
+{
+    size_t i;
+    /* p points at the locktime. Need locktime(4) + expiry(4) + valueBalance(8) + 3 = 19. */
+    const size_t need = sizeof(uint32_t) + sizeof(uint32_t) + ZEC_V4_TRAILER_ZEROS;
+    if (avail < need)
+        return WALLY_EINVAL;
+
+    /* valueBalanceSapling (bytes 8..15, relative to locktime) must be 0 (transparent only). */
+    for (i = 8; i < 8 + sizeof(uint64_t); ++i)
+        if (p[i])
+            return WALLY_EINVAL;
+
+    /* nShieldedSpend + nShieldedOutput + nJoinSplit counts (bytes 16..18) must be 0.
+     * Drop this check when/if shielded transactions are supported. */
+    if (p[16] || p[17] || p[18])
+        return WALLY_EINVAL;
+
+    return WALLY_OK;
+}
+
+const unsigned char *zec_v4_read_header(const unsigned char *p, struct wally_tx *tx)
+{
+    /* Read immediately after the 4-byte version. */
+    p += uint32_from_le_bytes(p, &tx->version_group_id);
+    return p;
+}
+
+const unsigned char *zec_v4_read_trailer(const unsigned char *p, struct wally_tx *tx)
+{
+    /* p points at the locktime (already parsed by the caller without advancing). */
+    p += sizeof(uint32_t);                       /* advance past locktime          */
+    p += uint32_from_le_bytes(p, &tx->expiry_height);
+    p += ZEC_V4_TRAILER_ZEROS;                   /* skip valueBalance + 3 varints  */
+    return p;
+}
+
+int zec_psbt_extract_branch_id(struct wally_psbt *psbt)
+{
+    size_t i;
+
+    psbt->branch_id = 0;
+    for (i = 0; i < psbt->unknowns.num_items; ++i) {
+        const struct wally_map_item *item = &psbt->unknowns.items[i];
+        if (item->key_len == ZEC_PROP_KEY_BRANCH_ID_LEN &&
+            !memcmp(item->key, ZEC_PROP_KEY_BRANCH_ID, ZEC_PROP_KEY_BRANCH_ID_LEN) &&
+            item->value_len == sizeof(uint32_t)) {
+            uint32_from_le_bytes(item->value, &psbt->branch_id); /* alignment-safe */
+            break;
+        }
+    }
+    return WALLY_OK;
+}
+
+#endif /* WALLY_ZCASH */


### PR DESCRIPTION
This changes will have libwally parse ZECv4 non-shielded overwintered and transparent-only PSBTs. The new exposed fields needed by the higher level API for calculating the signing hashes and also for validation and internal parsing are as follow:

On `wally_psbt` struct:
- branch_id: ZCASH's `CONSENSUS_BRANCH_ID`

On `wally_tx`:
- version_group_id
- expiry_height